### PR TITLE
[Fix] ETag error response from HuggingFace

### DIFF
--- a/lib/audio_tagger/keyword_finder.ex
+++ b/lib/audio_tagger/keyword_finder.ex
@@ -36,7 +36,7 @@ defmodule AudioTagger.KeywordFinder do
     {:ok, model_info} =
       Bumblebee.load_model({:hf, "vblagoje/bert-english-uncased-finetuned-pos"})
 
-    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "bert-base-uncased"})
+    {:ok, tokenizer} = Bumblebee.load_tokenizer({:hf, "google-bert/bert-base-uncased"})
 
     Bumblebee.Text.token_classification(model_info, tokenizer,
       aggregation: :same,

--- a/mix.exs
+++ b/mix.exs
@@ -29,7 +29,7 @@ defmodule AudioTagger.MixProject do
       # {:kino_bumblebee, "~> 0.4.0"},
       # {:kino_explorer, "~> 0.1.11"}
 
-      {:bumblebee, "~> 0.4.0"},
+      {:bumblebee, "~> 0.4.2"},
       {:exla, ">= 0.0.0"},
       {:explorer, "~> 0.7.0"}
     ]


### PR DESCRIPTION
The following error started showing recently when starting the app:

```elixir
** (Mix) Could not start application medical_transcription: exited in: MedicalTranscription.Application.start(:normal, [])
    ** (EXIT) an exception was raised:
        ** (MatchError) no match of right hand side value: {:error, "no ETag found on the resource"}
            (audio_tagger 0.1.0) lib/audio_tagger/keyword_finder.ex:39: AudioTagger.KeywordFinder.token_classification_serving/0
            (audio_tagger 0.1.0) lib/audio_tagger/keyword_finder.ex:49: AudioTagger.KeywordFinder.token_classification_child_spec/1
            (medical_transcription 0.1.0) lib/medical_transcription/application.ex:22: MedicalTranscription.Application.start/2
            (kernel 9.2) application_master.erl:293: :application_master.start_it_old/4
```